### PR TITLE
Sm map

### DIFF
--- a/src/app/shakemap/map/map.component.html
+++ b/src/app/shakemap/map/map.component.html
@@ -1,9 +1,13 @@
-<ng-container *ngIf="eventService.event$ | async; let event">
+<ng-container *ngIf="eventService.product$ | async; let product">
   <a
-      [routerLink]="'../map'"
-      [queryParams]="{ 'shakemap-intensity': true }">
+      [routerLink]="'../../map'"
+      [queryParams]="{
+        'shakemap-code': product?.code,
+        'shakemap-intensity': true,
+        'shakemap-source': product?.source
+      }">
     <shared-map
-        [overlays]="event | getProduct:'shakemap' | shakemapOverlays"
+        [overlays]="product | shakemapOverlays"
         [showScaleControl]="true">
     </shared-map>
   </a>

--- a/src/app/shakemap/shakemap/shakemap.component.html
+++ b/src/app/shakemap/shakemap/shakemap.component.html
@@ -10,10 +10,9 @@
   <nav mat-tab-nav-bar>
     <a mat-tab-link [routerLink]="'./map'"
         queryParamsHandling="preserve"
-        [queryParams]="{ 'shakemap-intensity': true }"
         routerLinkActive #map="routerLinkActive"
         [active]="map.isActive">
-      ShakeMap
+      Intensity
     </a>
     <a mat-tab-link [routerLink]="'./metadata'"
         queryParamsHandling="preserve"

--- a/src/app/shared/map/map.component.ts
+++ b/src/app/shared/map/map.component.ts
@@ -206,8 +206,10 @@ export class MapComponent implements AfterViewInit, OnInit {
       bounds = [[85.0, 180.0], [-85.0, 180.0]];
     }
 
-    this.map.fitBounds(bounds);
-    this.map.invalidateSize();
+    setTimeout(() => {
+      this.map.fitBounds(bounds);
+      this.map.invalidateSize();
+    }, 0);
   }
 
   updateControls () {


### PR DESCRIPTION
It looks like you were on the right track.  These changes include the setTimeout, but also a couple improvements:

- eventService.product$ has the currently selected product; which may or may not be the preferred ShakeMap (e.g., if browsing from the intensity overview page)

- the router link and params were a little off.  added the parameters for the interactive map to load the correct product.

Try http://localhost:4200/nc216859/impact to see how this works with different products from different contributors...